### PR TITLE
Added functionality to run a single source file (instead of the whole testing suite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ Total Score:    100.00%
 
 The output of this command is **identical to what is visible on Gradescope pre-due date**, and they are the same cases that display on every submission. If there is a discrepancy, please let the teaching team know!
 
+You may also specify a source file to the tester. This will run only the source file and not the rest of the tester. With this, you would manually specify input and would see the output in stdout.
+
+```sh
+$ python3 tester.py 1 v1/tests/test_add1.br
+15
+```
+
+*Of course, you may specify any source file, not just ones we provide!*
+
 Note: we also output the results of the terminal output to `results.json`.
 
 ## Bug Bounty

--- a/tester.py
+++ b/tester.py
@@ -141,6 +141,18 @@ def generate_test_suite_v1():
         fails,
     )
 
+def run_single_file(interpreterlib, srcfile):
+    """runs the interpreter on a single srcfile (instead of the entire test suite)"""
+
+    # creates an interpreter (with the ability to print to stdout)
+    interpreter = interpreterlib.Interpreter()
+    
+    # read the file (if file not found, just send the error /shrug)
+    with open(srcfile, 'r', encoding='utf-8') as handle:
+        prog_lines = handle.readlines()
+
+    program = "\n".join(prog_lines)
+    interpreter.run(program)
 
 async def main():
     """main entrypoint: argparses, delegates to test scaffold, suite generator, gradescope output"""
@@ -149,6 +161,18 @@ async def main():
     version = sys.argv[1]
     module_name = f"interpreterv{version}"
     interpreter = importlib.import_module(module_name)
+
+    # check if a file was specified
+    try:
+        srcfile = sys.argv[2]
+    except IndexError:
+        srcfile = None
+
+    if srcfile is not None:
+        run_single_file(interpreter, srcfile) 
+
+        # don't run the rest of the suite if a file is specified, just run the file
+        return
 
     scaffold = TestScaffold(interpreter)
 


### PR DESCRIPTION
# Motivation

* Some students on Campuswire seemed confused at how to structure programs, specifying input, etc for the autograder. For those most part, those have been resolved this quarter, but I can imagine that might come up again in the future
* Tests done on the interpreter for correctness are based entirely on some form of output. The current testing framework does not show that output to the terminal, making it less ergonomic for a student to see what their program might be doing
* Writing programs in multiline strings is (IMO) kinda cringe. For CS students, it makes more sense to be able to write a source file and run that in their interpreter.

# Feature

* The tester now parses up to 2 positional arguments. The first one is still the version number, but a second source file path can be specified to run the student's `interpreterv<versionno>.py` on that particular source file instead of the entire testing suite. 
* Running it this way allows the student to manually input into their program and test the output (without needing to add a formal test to the tester). 
* This method is also more flexible if the student chooses to run the debugger. The current testing suite offers no way to run only a single test (without modifying tester.py) so figuring out which test you are running can be a hassle and adds needless overhead into the debugging process. 
* Provided the interface of the `InterpreterBase` class doesn't change (at least we maintain that `Interpreter` needs to implement a `.run(self, program)` method to run a program) and that programs continue to be specified as multiline strings, this change can be incorporated into future quarters with little, if any, maintenance.

## Usage

```sh
$ python3 tester.py 1 v1/tests/test_add1.br
15
```

# Changelog

* `tester.py`
    * Added `run_single_file` to create a new `Interpreter` object to run a specified `srcfile`
    * Changed `main` to check for an additional positional argument
* `README.md`
    * Added information for using the new feature for running a single file

# Notes

* This was tested on Sp23's autograder with my implementation of the project last Spring. That one had programs in list form (as opposed to a multiline string) and had some other changes to the testing format. As a result, while I have made adjustments to attempt to reconcile these difference, **I make no guarantees that the current solution works as is and may require additional testing with canonical solutions for Fa23 and future quarters**. 